### PR TITLE
Remove Google secrets from repo

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -241,10 +241,10 @@ Devise.setup do |config|
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
   require 'omniauth-google-oauth2'
-  config.omniauth :google_oauth2, "459892137518-4dbpdd2r0a7bsrjc1dovngrb4kvvi4i8.apps.googleusercontent.com", 
-                                  "E1UNqKaSJfavoHMqUyo96aTJ", 
+  config.omniauth :google_oauth2, Rails.application.secrets.google_client_id,
+                                  Rails.application.secrets.google_client_secret,
                                   { access_type: "offline", approval_prompt: ""}
-  
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -20,3 +20,5 @@ test:
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  google_client_id: <%= ENV["GOOGLE_CLIENT_ID"] %>
+  google_client_secret: <%= ENV["GOOGLE_CLIENT_SECRET"] %>


### PR DESCRIPTION
This change removes the Google secrets from the repository. They
will now be loaded as environment variables by default.